### PR TITLE
fix(async-component): 修正 bundle[`${key}.json`].source 赋值问题

### DIFF
--- a/src/plugin/async-component-processor.ts
+++ b/src/plugin/async-component-processor.ts
@@ -153,7 +153,7 @@ export function AsyncComponentProcessor(options: DtsType, enableLogger: boolean)
             type: 'asset',
             name: key,
             fileName: `${key}.json`,
-            source: JSON.stringify({ usingComponents, componentPlaceholder }, null, 2),
+            source: JSON.stringify(Object.assign({}, cache, { usingComponents, componentPlaceholder }), null, 2),
           } as typeof bundle.__proto__
         }
       })


### PR DESCRIPTION
link #13  
可能是这个赋值的方式造成的原本页面配置丢失